### PR TITLE
(feat) Add source map for console

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,5 +19,6 @@ module.exports = {
         }
       }
     ]
-  }
+  },
+  devtool: 'source-map'
 };


### PR DESCRIPTION
# changes

1. Add `devtool: "source-map"` so logs and errors show proper code line instead of `bundle.js`

# before
<img width="291" alt="screen shot 2017-05-16 at 4 34 43 pm" src="https://cloud.githubusercontent.com/assets/892749/26132522/d247ffd6-3a55-11e7-913f-8df33d5a8b83.png">

# after
<img width="294" alt="screen shot 2017-05-16 at 4 33 54 pm" src="https://cloud.githubusercontent.com/assets/892749/26132527/d72c7fd6-3a55-11e7-98fb-d58ac94d9eb8.png">

