### PR TITLE
(bug) Add back a 38th major

### DIFF
--- a/UFORU_2017-05-11.sql
+++ b/UFORU_2017-05-11.sql
@@ -72,7 +72,8 @@ VALUES
 	(34,'Education'),
 	(35,'English'),
 	(36,'Visual and Performing Arts'),
-	(37,'Communication')
+	(37,'Communication'),
+	(38,'Whatever Seiden Studied');
 
 /*!40000 ALTER TABLE `Majors` ENABLE KEYS */;
 UNLOCK TABLES;


### PR DESCRIPTION
The DB would not init with the SQL dump insertion queries as long as there was not a 38th major